### PR TITLE
Update env variables setting in github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,17 +25,17 @@ jobs:
         run: python scripts/set_versions.py
 
       - name: Bug Fix
-        run: echo $JAVA_VERSION
+        run: echo ${{ env.JAVA_VERSION }}
 
       - name: SET
         run: echo "test=value >> $GITHUB_ENV"
 
       - name: GET
-        run: echo $test
+        run: echo ${{ env.test }}
 
       - uses: actions/setup-java@v1
         with:
-          java-version: $JAVA_VERSION
+          java-version: ${{ env.JAVA_VERSION }}
           java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
           architecture: x64
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false # To not cancel other platforms when one fails
     name: Test on ${{ matrix.os }} with Python ${{ matrix.python }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: "x64"
@@ -33,7 +33,7 @@ jobs:
       - name: GET
         run: echo $test
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
           java-version: $JAVA_VERSION
           java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         run: python scripts/set_versions.py
 
       - name: Bug Fix
-        run: echo env.JAVA_VERSION
+        run: echo $JAVA_VERSION
 
       - name: SET
         run: echo "test=value" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,13 +25,13 @@ jobs:
         run: python scripts/set_versions.py
 
       - name: Bug Fix
-        run: echo ${{ env.JAVA_VERSION }}
+        run: echo env.JAVA_VERSION
 
       - name: SET
         run: echo "test=value >> $GITHUB_ENV"
 
       - name: GET
-        run: echo ${{ env.test }}
+        run: echo env.test
 
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,9 @@ jobs:
           architecture: "x64"
 
       - name: Set Java version
-        run: python scripts/set_versions.py
-        run: echo $JAVA_VERSION
+        run: |
+          python scripts/set_versions.py
+          echo $JAVA_VERSION
 
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set Java version
         run: python scripts/set_versions.py
 
-       - name: Bug Fix
+      - name: Bug Fix
         run: echo $JAVA_VERSION
 
       - uses: actions/setup-java@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: GET
         run: echo $test
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v1
         with:
           java-version: $JAVA_VERSION
           java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,18 +24,6 @@ jobs:
       - name: Set Java version
         run: python scripts/set_versions.py
 
-      - name: Bug Fix
-        run: echo $JAVA_VERSION
-
-      - name: SET
-        run: echo "test=value" >> $GITHUB_ENV
-
-      - name: GET
-        run: echo $test
-
-      - name: GET2
-        run: echo $GITHUB_ENV
-
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,13 +22,14 @@ jobs:
           architecture: "x64"
 
       - name: Set Java version
-        run: |
-          python scripts/set_versions.py
-          echo $JAVA_VERSION
+        run: python scripts/set_versions.py
+
+       - name: Bug Fix
+        run: echo $JAVA_VERSION
 
       - uses: actions/setup-java@v1
         with:
-          java-version: ${{ env.JAVA_VERSION }}
+          java-version: $JAVA_VERSION
           java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
           architecture: x64
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,10 +28,10 @@ jobs:
         run: echo env.JAVA_VERSION
 
       - name: SET
-        run: echo "test=value >> $GITHUB_ENV"
+        run: echo "test=value" >> $GITHUB_ENV
 
       - name: GET
-        run: echo env.test
+        run: echo $test
 
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: GET
         run: echo $test
 
+      - name: GET2
+        run: echo $GITHUB_ENV
+
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Set Java version
         run: python scripts/set_versions.py
+        run: echo $JAVA_VERSION
 
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,10 +28,10 @@ jobs:
         run: echo $JAVA_VERSION
 
       - name: SET
-        run: echo "TEST=value >> $GITHUB_ENV"
+        run: echo "test=value >> $GITHUB_ENV"
 
       - name: GET
-        run: echo $TEST
+        run: echo $test
 
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,12 @@ jobs:
       - name: Bug Fix
         run: echo $JAVA_VERSION
 
+      - name: SET
+        run: echo "TEST=value >> $GITHUB_ENV"
+
+      - name: GET
+        run: echo $TEST
+
       - uses: actions/setup-java@v1
         with:
           java-version: $JAVA_VERSION

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -7,7 +7,7 @@ _LIB_VERSION_FILENAME = "lib_version.txt"
 
 def set_env_variable_in_github_job(name: str, value: str):
     # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
-    print(f"\"{name}={value}\" >> $GITHUB_ENV")
+    print(f"echo \"{name}={value}\" >> $GITHUB_ENV")
 
 
 def set_java_version_env_variable_in_github_job():

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -6,7 +6,7 @@ _JAVA_VERSION_FILENAME = "java_version.txt"
 _LIB_VERSION_FILENAME = "lib_version.txt"
 
 def set_env_variable_in_github_job(name: str, value: str):
-    # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+    # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
     print(f"{name}={value} >> $GITHUB_ENV")
 
 

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 _PROJECT_DIRECTORY = Path(__file__).parent.parent
@@ -7,7 +8,7 @@ _LIB_VERSION_FILENAME = "lib_version.txt"
 
 def set_env_variable_in_github_job(name: str, value: str):
     # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
-    print(f"echo \"{name}={value}\" >> $GITHUB_ENV")
+    os.popen(f"echo \"{name}={value}\" >> $GITHUB_ENV")
 
 
 def set_java_version_env_variable_in_github_job():

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -7,7 +7,7 @@ _LIB_VERSION_FILENAME = "lib_version.txt"
 
 def set_env_variable_in_github_job(name: str, value: str):
     # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
-    print(f"'{name}={value}' >> $GITHUB_ENV")
+    print(f"\"{name}={value}\" >> $GITHUB_ENV")
 
 
 def set_java_version_env_variable_in_github_job():

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -9,9 +9,8 @@ _LIB_VERSION_FILENAME = "lib_version.txt"
 def set_env_variable_in_github_job(name: str, value: str):
     # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
     f=open(os.environ["GITHUB_ENV"], "a")
-    f.write(f"{name}={value}")
+    f.write(f"{name}={value}\n")
     f.close()
-    # os.popen(f"echo \"{name}={value}\" >> $GITHUB_ENV")
 
 
 def set_java_version_env_variable_in_github_job():

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -8,9 +8,8 @@ _LIB_VERSION_FILENAME = "lib_version.txt"
 
 def set_env_variable_in_github_job(name: str, value: str):
     # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
-    f=open(os.environ["GITHUB_ENV"], "a")
-    f.write(f"{name}={value}\n")
-    f.close()
+    with open(os.environ["GITHUB_ENV"], "a") as environment_file:
+        environment_file.write(f"{name}={value}\n")
 
 
 def set_java_version_env_variable_in_github_job():

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -6,8 +6,8 @@ _JAVA_VERSION_FILENAME = "java_version.txt"
 _LIB_VERSION_FILENAME = "lib_version.txt"
 
 def set_env_variable_in_github_job(name: str, value: str):
-    # See https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
-    print(f"::set-env name={name}::{value}")
+    # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+    print(f"{name}={value} >> $GITHUB_ENV")
 
 
 def set_java_version_env_variable_in_github_job():

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -7,7 +7,7 @@ _LIB_VERSION_FILENAME = "lib_version.txt"
 
 def set_env_variable_in_github_job(name: str, value: str):
     # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
-    print(f"{name}={value} >> $GITHUB_ENV")
+    print(f"'{name}={value}' >> $GITHUB_ENV")
 
 
 def set_java_version_env_variable_in_github_job():

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -8,7 +8,10 @@ _LIB_VERSION_FILENAME = "lib_version.txt"
 
 def set_env_variable_in_github_job(name: str, value: str):
     # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.
-    os.popen(f"echo \"{name}={value}\" >> $GITHUB_ENV")
+    f=open(os.environ["GITHUB_ENV"], "a")
+    f.write(f"{name}={value}")
+    f.close()
+    # os.popen(f"echo \"{name}={value}\" >> $GITHUB_ENV")
 
 
 def set_java_version_env_variable_in_github_job():


### PR DESCRIPTION
Fix issue in github action : https://github.com/atoti/jdk4py/pull/15/checks?check_run_id=1617641855.
The way of setting environment variables was deprecated.