### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -112,9 +112,11 @@ jobs:
         name: Deploy to PyPI [Windows]
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-        run: poetry run twine upload dist/* --username __token__ --password ${env:TWINE_PASSWORD}
+        run: | # Install twine with conda as poetry is broken after installing conda
+          conda install twine
+          twine upload dist/jdk4py-*.whl --username __token__ --password ${env:TWINE_PASSWORD}
       - if: matrix.os != 'windows-latest'
         name: Deploy to PyPI [Linux/macOS]
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-        run: poetry run twine upload dist/* --username __token__ --password $TWINE_PASSWORD
+        run: poetry run twine upload dist/jdk4py-*.whl --username __token__ --password $TWINE_PASSWORD

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 build:
   number: 0
   include_recipe: False
+  binary_relocation: False # Without that binaries are broken on Mac OS.
 
 requirements:
   build:


### PR DESCRIPTION
Fix the deployment on all OS:
 - Use `jdk4py-*.whl` to only umpload the wheel
 - Windows: install twine with conda as poetry seems broken after installing conda